### PR TITLE
Improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
-# Firebase Studio
+# Ansible Architect
 
-This is a NextJS starter in Firebase Studio.
+Ansible Architect is a Next.js application that helps you design and visualize Ansible playbooks. It provides a drag-and-drop builder, playbook validation, and YAML export so you can create automation tasks quickly.
 
-To get started, take a look at src/app/page.tsx...
+## Prerequisites
+
+- **Node.js**: version 20 or later
+- **npm**: comes bundled with Node.js
+
+## Installation
+
+Clone the repository and install dependencies:
+
+```bash
+npm install
+```
+
+## Usage
+
+Start the development server with:
+
+```bash
+npm run dev
+```
+
+Build the production app:
+
+```bash
+npm run build
+```
+
+After building you can start the server:
+
+```bash
+npm start
+```
+
+Additional scripts:
+
+- `npm run lint` – run ESLint
+- `npm run typecheck` – run TypeScript type checking
+
+## Project Structure
+
+The source code resides in the `src` directory. The initial entry point is `src/app/page.tsx`.
 


### PR DESCRIPTION
## Summary
- rewrite the README to describe Ansible Architect
- document Node.js prerequisite and install steps
- add instructions for development, building, and other npm scripts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685417d4c4608324b4403b787805ec44